### PR TITLE
call unlock only if this process still owns the lock

### DIFF
--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -71,7 +71,9 @@ module Mongoid
       begin
         yield
       ensure
-        self.unlock unless had_lock
+        if !had_lock && locked?
+          self.unlock
+        end
       end
     end
 

--- a/spec/mongoid-locker_spec.rb
+++ b/spec/mongoid-locker_spec.rb
@@ -185,6 +185,19 @@ describe Mongoid::Locker do
 
       remove_class Admin
     end
+
+    it "should not unlock if the document is not locked anymore(occurs when the lock has timed out and some other process might own the lock)" do
+      User.timeout_lock_after 1
+      @user.should_not_receive(:unlock)
+      @user.with_lock do
+        @user.should be_locked
+        User.first.should be_locked
+        sleep 2
+      end
+
+      @user.should_not be_locked
+      @user.reload.should_not be_locked
+    end
   end
 
   describe ".timeout_lock_after" do


### PR DESCRIPTION
calling unlock when the process doesn't own the lock anymore can have other side effects - some other process holding a valid lock will lose it.
