### PR TITLE
call unlock only if this process still owns the lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * added support for Mongoid 6
 * fix unlock already destroyed object - #38
 * remove use of Jeweler
+* allow unlock when process no longer owns the lock or the lock times out - #46
 * your contribution here
 
 ## 0.3.4 ([diff](https://github.com/mongoid/mongoid-locker/compare/v0.3.4...master?w=1))

--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -70,9 +70,9 @@ module Mongoid
     # @option opts [Boolean] :reload After acquiring the lock, reload the document - defaults to true
     # @return [void]
     def with_lock(opts = {})
-      have_lock = self.has_lock?
+      had_lock = self.has_lock?
 
-      unless have_lock
+      unless had_lock
         opts[:retries] = 1 if opts[:wait]
         lock(opts)
       end
@@ -80,7 +80,7 @@ module Mongoid
       begin
         yield
       ensure
-        unlock unless have_lock
+        unlock if locked? && !had_lock
       end
     end
 

--- a/spec/mongoid-locker_spec.rb
+++ b/spec/mongoid-locker_spec.rb
@@ -256,6 +256,22 @@ describe Mongoid::Locker do
 
       remove_class Admin
     end
+
+    context 'when a lock has timed out' do
+      before do
+        User.timeout_lock_after 1
+        @user.with_lock do
+          expect(@user).to be_locked
+          expect(User.first).to be_locked
+          sleep 2
+        end
+      end
+      it 'should remain unlocked' do
+        expect(@user).to_not receive(:unlock)
+        expect(@user).to_not be_locked
+        expect(@user.reload).to_not be_locked
+      end
+    end
   end
 
   describe '.timeout_lock_after' do


### PR DESCRIPTION
calling unlock when the process doesn't own the lock anymore can have other side effects - some other process holding a valid lock will lose it.