### PR TITLE
Replace time by UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.0.0 (Next)
 
 * Your contribution here.
+* [#57](https://github.com/mongoid/mongoid-locker/pull/57): `Time.now` replaced by `Time.now.utc` - [@dks17](https://github.com/dks17).
 * [#55](https://github.com/mongoid/mongoid-locker/pull/55): Customizable :locked_at and :locked_until fields - [@dks17](https://github.com/dks17).
 
 ### 0.3.6 (4/18/2018)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ queue_item.with_lock do
 
   # do stuff
 
-  queue_item.completed_at = Time.now
+  queue_item.completed_at = Time.now.utc
   queue_item.save!
 end
 ```

--- a/spec/mongoid-locker_spec.rb
+++ b/spec/mongoid-locker_spec.rb
@@ -154,7 +154,7 @@ describe Mongoid::Locker do
 
       it 'should retry the number of times given, if desired' do
         allow(@user).to receive(:acquire_lock).and_return(false)
-        allow(Mongoid::Locker::Wrapper).to receive(:locked_until).and_return(Time.now)
+        allow(Mongoid::Locker::Wrapper).to receive(:locked_until).and_return(Time.now.utc)
 
         expect(@user).to receive(:acquire_lock).exactly(6).times
         expect do
@@ -178,7 +178,7 @@ describe Mongoid::Locker do
 
       it 'should, by default, when retrying, sleep until the lock expires' do
         allow(@user).to receive(:acquire_lock).and_return(false)
-        allow(Mongoid::Locker::Wrapper).to receive(:locked_until).and_return(Time.now + 5.seconds)
+        allow(Mongoid::Locker::Wrapper).to receive(:locked_until).and_return(Time.now.utc + 5.seconds)
         allow(@user).to receive(:sleep) { |time| expect(time).to be_within(0.1).of(5) }
 
         expect do
@@ -202,7 +202,7 @@ describe Mongoid::Locker do
       it 'should override the default timeout' do
         User.timeout_lock_after 1
 
-        expiration = (Time.now + 3).to_i
+        expiration = (Time.now.utc + 3).to_i
         @user.with_lock timeout: 3 do
           expect(@user[@user.locked_until_field].to_i).to eq(expiration)
         end


### PR DESCRIPTION
Replaced `Time.now` by `Time.now.utc`.
I think this is helpfully for better synchronization of applications located in several time zones.

`Mongoid` [also uses](https://github.com/mongodb/mongoid/blob/537687d61882263e7b394b348ce788fb91561206/lib/mongoid/timestamps/created.rb#L26) `UTC`
```ruby
def set_created_at
  if !timeless? && !created_at
    time = Time.now.utc
    self.updated_at = time if is_a?(Updated) && !updated_at_changed?
    self.created_at = time
  end
  clear_timeless_option
end
```