### PR TITLE
Fix Travis Jruby job error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,16 +21,13 @@ end
 gemspec
 
 group :development do
-  gem 'bundler', '~> 1.1'
   gem 'guard-rspec'
   gem 'rb-fsevent', '~> 0.9.1'
 end
 
 group :development, :test do
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'mongoid-compatibility'
   gem 'mongoid-danger', '~> 0.1.1'
-  gem 'pry-byebug'
   gem 'rack', '~> 1.5'
   gem 'rake', '11.3.0'
   gem 'rspec', '~> 3.0'

--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -170,7 +170,7 @@ module Mongoid
 
         if attempts_left > 0
           # if not passed a retry_sleep value, we sleep for the remaining life of the lock
-          unless opts[:retry_sleep]
+          unless retry_sleep
             locked_until = Mongoid::Locker::Wrapper.locked_until(self)
             # the lock might be released since the last check so make another attempt
             next unless locked_until

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rspec'
 require 'mongoid-locker'
 require 'mongoid/compatibility'
-require 'byebug'
-require 'pry-byebug'
 
 ENV['RACK_ENV'] = 'test'
 


### PR DESCRIPTION
I would like fix Travis Jruby job which was broken in #55
```console
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
```
Also I added two small changes:

Does actually `bundler` need in `Gemfile`?
```ruby
gem 'bundler', '~> 1.1'
```

I think it is actually does't matter.
Value of what variable we should check `retry_sleep` or `opts[:retry_sleep]`?

```ruby
retry_sleep = opts[:retry_sleep]
# code
if attempts_left > 0
  # if not passed a retry_sleep value, we sleep for the remaining life of the lock
  unless opts[:retry_sleep] # <==
    locked_until = Mongoid::Locker::Wrapper.locked_until(self)
```


