### PR TITLE
Remove TTL and update unique index definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.0.2 (Next)
 
+* [#92](https://github.com/mongoid/mongoid-locker/pull/92): Remove TTL and update unique index definitions - [@cesarizu](https://github.com/cesarizu).
 * Your contribution here.
 
 ### 2.0.1 (2020-06-17)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ class User
   field :locked_at, type: Time
 
   field :age, type: Integer
-
-  index({ _id: 1, locking_name: 1 }, name: 'mongoid_locker_index', sparse: true, unique: true, expire_after_seconds: lock_timeout)
 end
 ```
 

--- a/spec/support/configurations_shared_context.rb
+++ b/spec/support/configurations_shared_context.rb
@@ -12,11 +12,7 @@ RSpec.shared_context 'default configuration' do
       field :locked_at, type: Time
 
       field :age, type: Integer
-
-      index({ _id: 1, locking_name: 1 }, name: 'mongoid_locker_index', sparse: true, unique: true, expire_after_seconds: lock_timeout)
     end
-
-    User.create_indexes
   end
 
   after(:context) do


### PR DESCRIPTION
This PR removes the TTL index as it would remove the whole document. Also removes the unique index on the `locking_name` field as it is not needed for the functionality of this gem.

Related to: https://github.com/mongoid/mongoid-locker/issues/91