### PR TITLE
Convert Travis tests to GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,82 @@
+name: Test
+
+on:
+  push:
+    branches: [ master, github-actions ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        mongo: ["mongo:3.6", "mongo:4.2"]
+        mongoid: ["5", "6", "7"]
+        ruby:
+        - 2.3.8
+        - 2.4.7
+        - 2.5.7
+        - 2.6.6
+        - 2.7.1
+        - jruby-9.1.17.0
+        - jruby-9.2.11.1
+        experimental: [false]
+        include:
+          - mongoid: "7"
+            ruby: "2.6.6"
+            coverage: "true"
+          - mongo: "mongo:4.2"
+            mongoid: "7"
+            ruby: "ruby-head"
+            experimental: true
+          - mongo: "mongo:4.2"
+            mongoid: "7"
+            ruby: "jruby-head"
+            experimental: true
+        exclude:
+          - ruby: "2.7.1"
+            mongoid: "5"
+
+    runs-on: ubuntu-latest
+
+    continue-on-error: ${{ matrix.experimental }}
+
+    services:
+      mongo:
+        image: ${{ matrix.mongo }}
+        ports: ["27017:27017"]
+
+    env:
+      MONGOID_VERSION: ${{ matrix.mongoid }}
+      COVERAGE: ${{ matrix.coverage }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Checks
+      if: ${{ matrix.coverage == 'true' }}
+      run: |
+        bundle exec rubocop
+        # Disabled until mongoid-danger is updated to support Github Actions
+        # bundle exec danger
+
+    - name: Run tests
+      run: bundle exec rspec
+
+    - name: Code Climate
+      if: ${{ success() && matrix.coverage == 'true' }}
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
+        chmod +x ./cc-test-reporter;
+        ./cc-test-reporter before-build;
+        ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json coverage/.resultset.json;
+        ./cc-test-reporter upload-coverage;
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,16 @@
-services:
-  - mongodb
-
 language: ruby
 
 cache: bundler
 
-script:
-  - bundle exec rspec
-
 rvm:
-  - 2.3.8
-  - 2.4.7
-  - 2.5.7
   - 2.6.6
-  - 2.7.1
-  - jruby-9.1.17.0
-  - jruby-9.2.11.1
 
 env:
-  - MONGOID_VERSION=5
-  - MONGOID_VERSION=6
   - MONGOID_VERSION=7
 
-matrix:
-  include:
-    - rvm: 2.6.6
-      env:
-        - MONGOID_VERSION=7
-        - COVERAGE=true
-      before_script:
-        - bundle exec rubocop
-        - bundle exec danger
-      after_script:
-        - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
-            chmod +x ./cc-test-reporter;
-            ./cc-test-reporter before-build;
-            ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json coverage/.resultset.json;
-            ./cc-test-reporter upload-coverage;
-          fi
-    - rvm: ruby-head
-      env: MONGOID_VERSION=7
-    - rvm: jruby-head
-      env: MONGOID_VERSION=7
-  exclude:
-    - rvm: 2.7.1
-      env: MONGOID_VERSION=5
-  fast_finish: true
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
+before_script:
+  - bundle exec danger
 
-bundler_args: --without development
+script:
+  - echo SKIP
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.0.2 (Next)
 
+* [#92](https://github.com/mongoid/mongoid-locker/pull/92): Remove TTL and update unique index definitions - [@cesarizu](https://github.com/cesarizu).
 * Your contribution here.
 
 ### 2.0.1 (2020-06-17)

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 group :development, :test do
   gem 'pry-byebug', platforms: :mri
 
+  gem 'mongoid-compatibility'
   gem 'mongoid-danger', '~> 0.1.1'
   gem 'rspec', '~> 3.9'
   gem 'rubocop', '0.81.0'

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ class User
   field :locked_at, type: Time
 
   field :age, type: Integer
-
-  index({ _id: 1, locking_name: 1 }, name: 'mongoid_locker_index', sparse: true, unique: true, expire_after_seconds: lock_timeout)
 end
 ```
 

--- a/spec/support/configurations_shared_context.rb
+++ b/spec/support/configurations_shared_context.rb
@@ -12,11 +12,7 @@ RSpec.shared_context 'default configuration' do
       field :locked_at, type: Time
 
       field :age, type: Integer
-
-      index({ _id: 1, locking_name: 1 }, name: 'mongoid_locker_index', sparse: true, unique: true, expire_after_seconds: lock_timeout)
     end
-
-    User.create_indexes
   end
 
   after(:context) do

--- a/spec/support/locker_is_included_shared_examples.rb
+++ b/spec/support/locker_is_included_shared_examples.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'mongoid/compatibility'
+
 RSpec.shared_examples 'Mongoid::Locker is included' do
   include_examples 'delegated methods'
   it_behaves_like 'attr_accessor methods' do
@@ -128,7 +130,7 @@ RSpec.shared_examples 'Mongoid::Locker is included' do
     it 'is chainable' do
       expect do
         criteria = model.where(_id: 1).unlocked.where(_id: 2)
-        expect(criteria.selector['_id']).to eq(2)
+        expect(criteria.selector['_id']).to eq(Mongoid::Compatibility::Version.mongoid6_or_older? ? 2 : 1)
       end.not_to raise_error
     end
 


### PR DESCRIPTION
This PR converts Travis tests to GitHub actions. Currently all tests that pass in Travis are passing here as well. There are new tests using MongoDB 4.2.

Currently includes changes from: https://github.com/mongoid/mongoid-locker/pull/92