### PR TITLE
Restore a working CI with GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,12 +71,13 @@ jobs:
     - name: Run tests
       run: bundle exec rspec
 
-    - name: Code Climate
-      if: ${{ success() && matrix.coverage == 'true' }}
-      run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
-        chmod +x ./cc-test-reporter;
-        ./cc-test-reporter before-build;
-        ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json coverage/.resultset.json;
-        ./cc-test-reporter upload-coverage;
+# Disabled: you must supply a CC_TEST_REPORTER_ID ENV variable or pass it via the -r flag
+#    - name: Code Climate
+#      if: ${{ success() && matrix.coverage == 'true' }}
+#      run: |
+#        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
+#        chmod +x ./cc-test-reporter;
+#        ./cc-test-reporter before-build;
+#        ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json coverage/.resultset.json;
+#        ./cc-test-reporter upload-coverage;
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,13 +71,11 @@ jobs:
     - name: Run tests
       run: bundle exec rspec
 
-# Disabled: you must supply a CC_TEST_REPORTER_ID ENV variable or pass it via the -r flag
-#    - name: Code Climate
-#      if: ${{ success() && matrix.coverage == 'true' }}
-#      run: |
-#        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
-#        chmod +x ./cc-test-reporter;
-#        ./cc-test-reporter before-build;
-#        ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json coverage/.resultset.json;
-#        ./cc-test-reporter upload-coverage;
-
+    - name: Code Climate
+      if: ${{ env.CC_TEST_REPORTER_ID != '' && success() && matrix.coverage == 'true' }}
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
+        chmod +x ./cc-test-reporter;
+        ./cc-test-reporter before-build;
+        ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json coverage/.resultset.json;
+        ./cc-test-reporter upload-coverage;

--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,5 @@ group :development, :test do
   gem 'rspec', '~> 3.9'
   gem 'rubocop', '0.81.0'
   gem 'rubocop-rspec', '1.38.1'
-  gem 'simplecov', require: false
+  gem 'simplecov', '0.17', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,5 @@ group :development, :test do
   gem 'rspec', '~> 3.9'
   gem 'rubocop', '0.81.0'
   gem 'rubocop-rspec', '1.38.1'
-  gem 'simplecov', '0.17', require: false
+  gem 'simplecov', require: false
 end

--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -138,8 +138,7 @@ module Mongoid
         where(
           '$and': [
             { locking_name_field => { '$exists': true, '$ne': nil } },
-            { locked_at_field => { '$exists': true, '$ne': nil } },
-            { '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}" }
+            { locked_at_field => { '$gte': Time.now.utc - (lock_timeout * 1000) } }
           ]
         )
       end
@@ -168,9 +167,7 @@ module Mongoid
                 { locked_at_field => { '$eq': nil } }
               ]
             },
-            {
-              '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"
-            }
+            { locked_at_field => { '$lt': Time.now.utc - (lock_timeout * 1000) } }
           ]
         )
       end

--- a/spec/support/populate_database_shared_context.rb
+++ b/spec/support/populate_database_shared_context.rb
@@ -42,6 +42,6 @@ end
 
 RSpec.shared_context 'with a populated database', :populate do
   include_context 'with a document'
-  include_context 'With a locked document'
-  include_context 'With an unlocked document'
+  include_context 'with a locked document'
+  include_context 'with an unlocked document'
 end

--- a/spec/test_examples_spec.rb
+++ b/spec/test_examples_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Test examples' do
 
       expect do
         CustomerService.new(customer).add_amount!(7)
-      end.not_to change(customer.reload.amount)
+      end.not_to change(customer.reload, :amount)
     end
 
     it 'does not add amount to customer 2' do
@@ -69,7 +69,7 @@ RSpec.describe 'Test examples' do
 
       expect do
         CustomerService.new(customer).add_amount!(7)
-      end.not_to change(customer.reload.amount)
+      end.not_to change(customer.reload, :amount)
     end
   end
 end


### PR DESCRIPTION
## Purpose

Restoring the CI with GHA before adding support to mongoid v8. For more context see the issue https://github.com/mongoid/mongoid-locker/issues/94

## Changes
- Change the syntax of using the change method.
- Disable the Code Climate step _(you must supply a CC_TEST_REPORTER_ID ENV variable or pass it via the -r flag)_.
- Refactor the query to get locked and unlocked documents.
- Fix typo in specs.

## TODO
The experimental cases of the matrix still fail, the reason seems to be that the version **7** of `mongoid/i18n` doesn't support ruby 3 👇🏼 
https://github.com/rsosag/mongoid-locker/actions/runs/3834210130