### PR TITLE
Add mongoid 8.0.x support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,10 @@ jobs:
         exclude:
           - ruby: "2.7.1"
             mongoid: "5"
+          - ruby: "3.0.5"
+            mongoid: "5"
+          - ruby: "3.1.3"
+            mongoid: "5"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches: [ master, github-actions ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -12,50 +8,38 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mongo: ["mongo:3.6", "mongo:4.2"]
-        mongoid: ["5", "6", "7", "8"]
-        ruby:
-        - 2.3.8
-        - 2.4.7
-        - 2.5.7
-        - 2.6.6
-        - 2.7.1
-        - 3.0.5
-        - 3.1.3
-        - jruby-9.1.17.0
-        - jruby-9.2.11.1
+        entry:
+          - { ruby: '2.6.6', mongo: 'mongo:4.4', mongoid: '5' }
+          - { ruby: 'jruby-9.1.17.0', mongo: 'mongo:4.4', mongoid: '5' }
+          - { ruby: 'jruby-9.2.11.1', mongo: 'mongo:4.4', mongoid: '5' }
+          - { ruby: '2.6.6', mongo: 'mongo:4.4', mongoid: '6' }
+          - { ruby: '2.7.1', mongo: 'mongo:4.4', mongoid: '6' }
+          - { ruby: '3.0.5', mongo: 'mongo:4.4', mongoid: '6' }
+          - { ruby: '3.1.3', mongo: 'mongo:4.4', mongoid: '6' }
+          - { ruby: 'jruby-9.2.11.1', mongo: 'mongo:4.4', mongoid: '6' }
+          - { ruby: '2.6.6', mongo: 'mongo:4.4', mongoid: '7', coverage: 'true' }
+          - { ruby: '2.7.1', mongo: 'mongo:4.4', mongoid: '7' }
+          - { ruby: '3.0.5', mongo: 'mongo:4.4', mongoid: '7' }
+          - { ruby: '3.1.3', mongo: 'mongo:4.4', mongoid: '7' }
+          - { ruby: 'jruby-9.2.11.1', mongo: 'mongo:4.4', mongoid: '7' }
+          - { ruby: '2.6.6', mongo: 'mongo:4.4', mongoid: '8' }
+          - { ruby: '2.7.1', mongo: 'mongo:4.4', mongoid: '8' }
+          - { ruby: '3.0.5', mongo: 'mongo:4.4', mongoid: '8' }
+          - { ruby: '3.1.3', mongo: 'mongo:4.4', mongoid: '8' }
         experimental: [false]
-        include:
-          - mongoid: "7"
-            ruby: "2.6.6"
-            coverage: "true"
-          - mongo: "mongo:4.2"
-            mongoid: "7"
-            ruby: "ruby-head"
-            experimental: true
-          - mongo: "mongo:4.2"
-            mongoid: "7"
-            ruby: "jruby-head"
-            experimental: true
-        exclude:
-          - ruby: "2.7.1"
-            mongoid: "5"
-          - ruby: "3.0.5"
-            mongoid: "5"
-          - ruby: "3.1.3"
-            mongoid: "5"
 
+    name: test (ruby=${{ matrix.entry.ruby }}, mongo=${{ matrix.entry.mongo }}), mongoid=${{ matrix.entry.mongoid }})
     runs-on: ubuntu-latest
 
     continue-on-error: ${{ matrix.experimental }}
 
     services:
       mongo:
-        image: ${{ matrix.mongo }}
+        image: ${{ matrix.entry.mongo }}
         ports: ["27017:27017"]
 
     env:
-      MONGOID_VERSION: ${{ matrix.mongoid }}
+      MONGOID_VERSION: ${{ matrix.entry.mongoid }}
       COVERAGE: ${{ matrix.coverage }}
 
     steps:
@@ -64,7 +48,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.entry.ruby }}
         bundler-cache: true
 
     - name: Checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
     env:
       MONGOID_VERSION: ${{ matrix.entry.mongoid }}
-      COVERAGE: ${{ matrix.coverage }}
+      COVERAGE: ${{ matrix.entry.coverage }}
 
     steps:
     - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
         bundler-cache: true
 
     - name: Checks
-      if: ${{ matrix.coverage == 'true' }}
+      if: ${{ matrix.entry.coverage == 'true' }}
       run: |
         bundle exec rubocop
         # Disabled until mongoid-danger is updated to support Github Actions
@@ -62,7 +62,7 @@ jobs:
       run: bundle exec rspec
 
     - name: Code Climate
-      if: ${{ env.CC_TEST_REPORTER_ID != '' && success() && matrix.coverage == 'true' }}
+      if: ${{ env.CC_TEST_REPORTER_ID != '' && success() && matrix.entry.coverage == 'true' }}
       run: |
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
         chmod +x ./cc-test-reporter;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - { ruby: '3.1.3', mongo: 'mongo:4.4', mongoid: '8' }
         experimental: [false]
 
-    name: test (ruby=${{ matrix.entry.ruby }}, mongo=${{ matrix.entry.mongo }}), mongoid=${{ matrix.entry.mongoid }})
+    name: test (ruby=${{ matrix.entry.ruby }}, mongo=${{ matrix.entry.mongo }}, mongoid=${{ matrix.entry.mongoid }})
     runs-on: ubuntu-latest
 
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         mongo: ["mongo:3.6", "mongo:4.2"]
-        mongoid: ["5", "6", "7"]
+        mongoid: ["5", "6", "7", "8"]
         ruby:
         - 2.3.8
         - 2.4.7
         - 2.5.7
         - 2.6.6
         - 2.7.1
+        - 3.0.5
+        - 3.1.3
         - jruby-9.1.17.0
         - jruby-9.2.11.1
         experimental: [false]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.0.2 (Next)
 
 * [#92](https://github.com/mongoid/mongoid-locker/pull/92): Remove TTL and update unique index definitions - [@cesarizu](https://github.com/cesarizu).
-* Your contribution here.
+* [#92](https://github.com/mongoid/mongoid-locker/pull/97): Add support for mongoid 8.0.x versions - [@randikabanura](https://github.com/randikabanura)
 
 ### 2.0.1 (2020-06-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,33 @@
 
 ### 2.0.2 (Next)
 
-* [#92](https://github.com/mongoid/mongoid-locker/pull/92): Remove TTL and update unique index definitions - [@cesarizu](https://github.com/cesarizu).
-* [#92](https://github.com/mongoid/mongoid-locker/pull/97): Add support for mongoid 8.0.x versions - [@randikabanura](https://github.com/randikabanura)
+* [#92](https://github.com/mongoid/mongoid-locker/pull/92): Removed TTL and updated unique index definitions - [@cesarizu](https://github.com/cesarizu).
+* [#92](https://github.com/mongoid/mongoid-locker/pull/97): Added support for mongoid 8.0.x versions - [@randikabanura](https://github.com/randikabanura).
+* Your contribution here.
 
 ### 2.0.1 (2020-06-17)
 
 * [#86](https://github.com/mongoid/mongoid-locker/pull/86): Upgraded to RuboCop 0.81.0 - [@dks17](https://github.com/dks17).
 * [#86](https://github.com/mongoid/mongoid-locker/pull/86): Fixed issue with `ruby` `delegate` method - [@dks17](https://github.com/dks17).
-* [#86](https://github.com/mongoid/mongoid-locker/pull/86): Update Ruby and JRUby versions for Travis config - [@dks17](https://github.com/dks17).
-* [#88](https://github.com/mongoid/mongoid-locker/pull/88): Add RSpec test examples - [@dks17](https://github.com/dks17).
+* [#86](https://github.com/mongoid/mongoid-locker/pull/86): Updated Ruby and JRUby versions for Travis config - [@dks17](https://github.com/dks17).
+* [#88](https://github.com/mongoid/mongoid-locker/pull/88): Added RSpec test examples - [@dks17](https://github.com/dks17).
 
 ### 2.0.0 (2019-10-23)
 
-* [#79](https://github.com/mongoid/mongoid-locker/pull/79): Update find_and_lock and find_and_unlock methods - [@dks17](https://github.com/dks17).
-* [#78](https://github.com/mongoid/mongoid-locker/pull/78): Upgrade to v2.0 - [@dks17](https://github.com/dks17).
+* [#79](https://github.com/mongoid/mongoid-locker/pull/79): Updated find_and_lock and find_and_unlock methods - [@dks17](https://github.com/dks17).
+* [#78](https://github.com/mongoid/mongoid-locker/pull/78): Upgraded to v2.0 - [@dks17](https://github.com/dks17).
 * [#83](https://github.com/mongoid/mongoid-locker/pull/83): Upgraded to RuboCop 0.75.1 - [@dblock](https://github.com/dblock).
 
 ### 1.0.1 (2019-03-23)
 
-* [#74](https://github.com/mongoid/mongoid-locker/pull/74): Add JRuby tests - [@dks17](https://github.com/dks17).
+* [#74](https://github.com/mongoid/mongoid-locker/pull/74): Added JRuby tests - [@dks17](https://github.com/dks17).
 * [#68](https://github.com/mongoid/mongoid-locker/pull/68): Fix Rubocop offenses, refactoring, update `ruby` versions, add `COVERAGE` test env, update `.travis.yml` matrix - [@dks17](https://github.com/dks17).
-* [#67](https://github.com/mongoid/mongoid-locker/pull/67): Deprecate `:wait` in favor of `:retries` option, which can attempt to grab a lock multiple times - [@afeld](https://github.com/afeld), [@dks17](https://github.com/dks17).
+* [#67](https://github.com/mongoid/mongoid-locker/pull/67): Deprecated `:wait` in favor of `:retries` option, which can attempt to grab a lock multiple times - [@afeld](https://github.com/afeld), [@dks17](https://github.com/dks17).
 * [#66](https://github.com/mongoid/mongoid-locker/pull/66): Fix Mongoid::Locker::LockError for not persisted document - [@dks17](https://github.com/dks17).
-* [#65](https://github.com/mongoid/mongoid-locker/pull/65): Drop `mongoid-compatibility` gem dependency - [@dks17](https://github.com/dks17).
+* [#65](https://github.com/mongoid/mongoid-locker/pull/65): Dropped `mongoid-compatibility` gem dependency - [@dks17](https://github.com/dks17).
 * [#64](https://github.com/mongoid/mongoid-locker/pull/64): Exclude demo files from the gem - [@dks17](https://github.com/dks17).
-* [#60](https://github.com/mongoid/mongoid-locker/pull/60): Drop support for `mongoid` version `2` and `3` - [@dks17](https://github.com/dks17).
-* [#60](https://github.com/mongoid/mongoid-locker/pull/60): Add SimpleCov - [@dks17](https://github.com/dks17).
+* [#60](https://github.com/mongoid/mongoid-locker/pull/60): Dropped support for `mongoid` version `2` and `3` - [@dks17](https://github.com/dks17).
+* [#60](https://github.com/mongoid/mongoid-locker/pull/60): Added SimpleCov - [@dks17](https://github.com/dks17).
 
 ### 1.0.0 (2018-09-02)
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@
 source 'https://rubygems.org'
 gemspec
 
-case ENV['MONGOID_VERSION']
+case ENV['MONGOID_VERSION'] || '8.0.3'
+when /^8/
+  gem 'mongoid', '~> 8.0'
 when /^7/
   gem 'mongoid', '~> 7.0'
 when /^6/

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-case ENV['MONGOID_VERSION'] || '8.0.3'
+case ENV['MONGOID_VERSION']
 when /^8/
   gem 'mongoid', '~> 8.0'
 when /^7/

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Document-level optimistic locking for MongoDB via Mongoid. Mongoid-Locker is an 
 **NOTE:** Please refer to [1-x-stable](https://github.com/mongoid/mongoid-locker/tree/1-x-stable) branch for `1.x.x` documentation. See the [UPGRADING](UPGRADING.md) guide and [CHANGELOG](CHANGELOG.md) for an overview of the changes.
 
 [Tested](https://travis-ci.org/mongoid/mongoid-locker) against:
-- MRI: `2.3.8`, `2.4.7`, `2.5.7`, `2.6.6`, `2.7.1`
+- MRI: `2.3.8`, `2.4.7`, `2.5.7`, `2.6.6`, `2.7.1`, `3.0.5`, `3.1.3`
 - JRuby `9.1.17.0`, `9.2.11.1`
-- Mongoid: `5`, `6`, `7`
+- Mongoid: `5`, `6`, `7`, `8`
 
 See [.travis.yml](.travis.yml) for the latest test matrix.
 

--- a/lib/mongoid/locker/errors.rb
+++ b/lib/mongoid/locker/errors.rb
@@ -8,7 +8,7 @@ module Mongoid
         BASE_KEY = 'mongoid.locker.errors.messages'
 
         def initialize(key, **params)
-          message = I18n.translate("#{BASE_KEY}.#{key}.message", params)
+          message = I18n.translate("#{BASE_KEY}.#{key}.message", **params)
 
           super("\nmessage:\n  #{message}")
         end

--- a/mongoid-locker.gemspec
+++ b/mongoid-locker.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'mongoid', '>= 5.0', '< 8'
+  s.add_dependency 'mongoid', '>= 5.0', '< 8.1'
 end

--- a/mongoid-locker.gemspec
+++ b/mongoid-locker.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'mongoid', '>= 5.0', '< 8.1'
+  s.add_dependency 'mongoid', '>= 5.0', '< 9'
 end


### PR DESCRIPTION
Mongoid has released the mongoid 8 version. hence this PR adds support for mongoid 8.0.x versions for the gem.

Tests are passing without an issue for new mongoid version.
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/44117822/211452621-01027b46-7d2b-4de4-a5c1-dc5e7eb838ed.png">

This closes #94 