### PR TITLE
Replace the $where operator with $expr

### DIFF
--- a/lib/mongoid/locker/wrapper.rb
+++ b/lib/mongoid/locker/wrapper.rb
@@ -35,8 +35,8 @@ module Mongoid
                 { model.locked_at_field => { '$eq': nil } }
               ]
             },
-            {
-              '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"
+            { # The expr equals to "Time.now.utc >= model.locked_at_field + model.lock_timeout * 1000"
+              '$expr': { '$gte': ['$$NOW', { '$add': ["$#{model.locked_at_field}", model.lock_timeout * 1000] }] }
             }
           ]
         }


### PR DESCRIPTION
This PR wants to replace the $where operator (not supported in MongoDB Atlas free tier) with to $expr operator, to fix the #100.

It use the [NOW](https://www.mongodb.com/docs/v4.4/reference/aggregation-variables/#mongodb-variable-variable.NOW) system variables to keep the comparison as faithful as possible to the query execution time.

