### PR TITLE
Revert introduction of `forwardable`

### DIFF
--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 require 'securerandom'
 
 module Mongoid
@@ -104,8 +103,6 @@ module Mongoid
 
       # @api private
       def included(klass)
-        klass.extend(Forwardable) unless klass.ancestors.include?(Forwardable)
-
         klass.extend ClassMethods
         klass.singleton_class.instance_eval { attr_accessor(*MODULE_METHODS) }
 
@@ -117,7 +114,7 @@ module Mongoid
         klass.backoff_algorithm = backoff_algorithm
         klass.locking_name_generator = locking_name_generator
 
-        klass.def_delegators(klass, *MODULE_METHODS)
+        klass.delegate(*MODULE_METHODS, to: :class)
         klass.singleton_class.delegate(*(methods(false) - MODULE_METHODS.flat_map { |method| [method, "#{method}=".to_sym] } - %i[included reset! configure]), to: self)
       end
     end


### PR DESCRIPTION
This PR attempts to fix an incompatibility between mongoid-locker >=  2.0.1 and mongoid-history. The issue was introduced [by this PR](https://github.com/mongoid/mongoid-locker/pull/86). See https://github.com/mongoid/mongoid-history/issues/238#issuecomment-1063155193 for an example report.

## Timeline
Here's a timeline of what I think happened:
1. Mongoid 7.1.0 introduced a regression (see https://jira.mongodb.org/browse/MONGOID-4849) by switching to the builtin ruby forwardable method of delegation rather than relying on the ActiveSupport-provided delegation used before.
2. mongoid-locker was made compatible with the regressed version of mongoid in https://github.com/mongodb/mongoid/pull/4739
3. Mongoid then fixed their regression in 7.1.1+ with https://github.com/mongodb/mongoid/commit/d078acdfb0648e5b07ace16ee3077d14bf65b931, which goes back to the active support way of delegating. (I'm not totally sure why mongoid-locker continued to work, but I think it's because requiring forwardable overrides what `delegate` does, so mongoid-locker gets its expected behavior but other gems have their `delegate` changed out from under them).

## Underlying issue
The `forwardable` inclusion in mongoid-locker causes incompatibilities when you then include another gem that expects to be able to set up a delegator within a mongoid document class. For example the `mongoid-history` gem expects to be able to delegate using the active-support style here: https://github.com/mongoid/mongoid-history/blob/c8c4de1235c01252dfbdb9fe6c0abfc078ec1443/lib/mongoid/history/trackable.rb#L24-L25

## Fix
This PR reverts the change to introduce `forwardable` to go back to using the ActiveSupport-provided `delegate`. 

